### PR TITLE
import modifier bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Build/Debug
 _UpgradeReport_Files
 x64
 Debug
+/Build
+/ipch/nifplugins_vc2008-4447fb5f
+/NifPlugins_VC2010.sdf

--- a/NifCommon/niutils.cpp
+++ b/NifCommon/niutils.cpp
@@ -804,13 +804,16 @@ Modifier *GetOrCreateSkin(INode *node)
    Modifier *skinMod = GetSkin(node);
    if (skinMod)
       return skinMod;   
-   
-   IDerivedObject *dobj = CreateDerivedObject(node->GetObjectRef());
+   Object *pObj = node->GetObjectRef();
+   IDerivedObject *pDerObj = NULL;
+   if (pObj->SuperClassID() == GEN_DERIVOB_CLASS_ID)
+	   pDerObj = static_cast<IDerivedObject*>(pObj);
+   else pDerObj = CreateDerivedObject(pObj);
    //create a skin modifier and add it
    skinMod = (Modifier*) CreateInstance(OSM_CLASS_ID, SKIN_CLASSID);
-   dobj->SetAFlag(A_LOCK_TARGET);
-   dobj->AddModifier(skinMod);
-   dobj->ClearAFlag(A_LOCK_TARGET);
+   pDerObj->SetAFlag(A_LOCK_TARGET);
+   pDerObj->AddModifier(skinMod);
+   pDerObj->ClearAFlag(A_LOCK_TARGET);
    node->SetObjectRef(dobj);
    return skinMod;
 }

--- a/NifProps/Modifier/BSDismemberSkin.cpp
+++ b/NifProps/Modifier/BSDismemberSkin.cpp
@@ -2510,19 +2510,24 @@ void BSDSModifier::SelectUnused()
    ip->RedrawViews(ip->GetTime());
 }
 
-// Get or Create the Skin Modifier
+// Get or Create the BSDismember Modifier
 Modifier *GetOrCreateBSDismemberSkin(INode *node)
 {
    Modifier *skinMod = GetBSDismemberSkin(node);
    if (skinMod)
       return skinMod;   
-
-   IDerivedObject *dobj = CreateDerivedObject(node->GetObjectRef());
-   //create a skin modifier and add it
+   Object *pObj = node->GetObjectRef();
+   IDerivedObject *pDerObj = NULL;
+   if (pObj->SuperClassID() == GEN_DERIVOB_CLASS_ID)
+	   pDerObj = static_cast<IDerivedObject*>(pObj);
+   else {
+	   pDerObj = CreateDerivedObject(pObj);
+   }
+   //create a BSDismember modifier and add it
    skinMod = (Modifier*) CreateInstance(OSM_CLASS_ID, BSDSMODIFIER_CLASS_ID);
-   dobj->SetAFlag(A_LOCK_TARGET);
-   dobj->AddModifier(skinMod);
-   dobj->ClearAFlag(A_LOCK_TARGET);
+   pDerObj->SetAFlag(A_LOCK_TARGET);
+   pDerObj->AddModifier(skinMod);
+   pDerObj->ClearAFlag(A_LOCK_TARGET);
    node->SetObjectRef(dobj);
    return skinMod;
 }


### PR DESCRIPTION
A set of small but hugely important bugfixes.

Previous code was erroneous and created multiple instances of derived objects in the mesh which lead to modifier instability and crashes with imported models.

New code checks to see if there already is an initialized  instance of derived object on the mesh and correctly links modifiers.

For more information and detailed graph of how 3dsmax mesh pipeline should be sorted refer to docs here: http://docs.autodesk.com/3DSMAX/16/ENU/3ds-Max-SDK-Programmer-Guide/index.html?url=files/GUID-A47BAC47-34AB-49BE-A8CF-1BB9162F0041.htm,topicNumber=d30e21806
